### PR TITLE
build.gradle.kts - use Hytale maven repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,15 @@ plugins {
 
 group = "fi.sulku.hytale"
 version = "2.0.0"
+val hytaleVersion = "2026.01.24-6e2d4fc36"
 
 repositories {
     mavenCentral()
+    maven("https://maven.hytale.com/release")
 }
 
 dependencies {
-    compileOnly(files("libs/HytaleServer.jar")) // Temp
+    compileOnly("com.hypixel.hytale:Server:${hytaleVersion}")
 }
 
 java {


### PR DESCRIPTION
I wanted to use your project in my project, and I was going to pull from the JitPack repo, but I saw the build failed.
I then realized you're using a local jar of the Hytale Server.

So this PR aims to update your repo to use the Hytale maven repo.

I created a val at the top for you to quickly change the Hytale version.
But if you dont like that, I can remove it and plop the version directly into the dependancy 